### PR TITLE
chore: update legal entity name to iGrant Technologies AB

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The table summarises the supported schemas.
 Feel free to improve the schemas and send us a pull request. If you found any problems, please create an issue in this repo.
 
 ## Licensing
-Copyright (c) 2021 LCubed AB (iGrant.io), Sweden
+Copyright (c) 2021 iGrant Technologies AB (iGrant.io), Sweden
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The table summarises the supported schemas.
 Feel free to improve the schemas and send us a pull request. If you found any problems, please create an issue in this repo.
 
 ## Licensing
-Copyright (c) 2021 iGrant Technologies AB (iGrant.io), Sweden
+Copyright (c) 2026 iGrant Technologies AB (iGrant.io), Sweden
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 


### PR DESCRIPTION
Our legal entity name is now **iGrant Technologies AB**, formerly **LCubed AB**.

This PR replaces references to the old legal entity name **LCubed AB** with the new name **iGrant Technologies AB** in licensing/copyright, legal, and current branding text.

Left unchanged: technical identifiers (e.g. app bundle ids), i18n keys, file names/URLs, and historical records.